### PR TITLE
Allow MPI pools

### DIFF
--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -86,6 +86,9 @@ class Sampler(object):
         else:
             self.pool = pool
 
+        if not hasattr(self.pool, 'map'):
+            raise AttributeError("Pool object must have a map() method.")
+
         self._transd = transd
         if self._transd:
             self._chain = ma.masked_all((0, self.nwalkers, self.dim))

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -4,7 +4,7 @@ from scipy.stats import chi2_contingency
 
 from .interruptible_pool import Pool
 from .clustered_kde import optimized_kde, TransdimensionalKDE
-
+from .serialpool import SerialPool
 
 class GetLnProbWrapper(object):
     def __init__(self, lnpost, kde):
@@ -73,10 +73,18 @@ class Sampler(object):
         self.iterations = 0
         self.stored_iterations = 0
 
-        self.pool = pool
         self.processes = processes
-        if self.processes != 1 and self.pool is None:
+
+        # operate in serial (1 process)
+        if pool is None:
+            pool = SerialPool()
+
+        # create a multiprocessing pool
+        elif self.processes != 1 and self.pool is None:
             self.pool = Pool(self.processes)
+
+        else:
+            self.pool = pool
 
         self._transd = transd
         if self._transd:
@@ -283,10 +291,7 @@ class Sampler(object):
                 #   Operations with masked arrays can be slow.
                 p = np.array(p0, copy=True)
 
-        if self.pool is None:
-            m = map
-        else:
-            m = self.pool.map
+        m = self.pool.map
 
         if kde_size:
             self._kde_size = kde_size
@@ -625,10 +630,8 @@ class Sampler(object):
         returned.  Usually you'll get:
         ``p``, ``lnpost``, ``lnprop``, ``blob``(optional)
         """
-        if self.pool is None:
-            m = map
-        else:
-            m = self.pool.map
+
+        m = self.pool.map
 
         if p0 is None:
             if self._last_run_mcmc_result is None:

--- a/kombine/serialpool.py
+++ b/kombine/serialpool.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+
+""" Utility class for a uniform Pool API for serial processing """
+
+class SerialPool(object):
+
+    def close(self):
+        return
+
+    def map(self, function, tasks, callback=None):
+        results = []
+        for task in tasks:
+            result = function(task)
+            if callback is not None:
+                callback(result)
+            results.append(result)
+        return results


### PR DESCRIPTION
I _think_ this is all you need in order to support MPI via [mpipool](https://github.com/dfm/mpipool). I just made the sampler more agnostic to what the pool object is, and to just assume it has a `map()` method. I also added a `SerialPool` object that mimics the API of the multiprocessing pool but is really just a wrapper around the built-in `map()` function.
