### PR TITLE
Fix bug in kde draws

### DIFF
--- a/kombine/clustered_kde.py
+++ b/kombine/clustered_kde.py
@@ -241,6 +241,14 @@ class KDE(object):
 
         self._set_bandwidth()
 
+        # store transformation variables for drawing random values
+        alphas = abs(data).max(axis=0)
+        ms = 1./alphas
+        m_i, m_j = numpy.meshgrid(ms, ms)
+        ms = m_i * m_j
+        self._draw_cov = ms * self._kernel_cov
+        self._scale_fac = alphas
+
     def __enter__(self):
         return self
 
@@ -276,7 +284,8 @@ class KDE(object):
             return []
 
         # Draw vanilla samples from a zero-mean multivariate Gaussian
-        draws = np.random.multivariate_normal(np.zeros(self.ndim), self._kernel_cov, size=size)
+        draws = self._scale_fac * np.random.multivariate_normal(np.zeros(self.ndim),
+                                                                self._draw_cov, size=size)
 
         # Pick N random kernels as means
         kernels = np.random.randint(0, self.size, size)

--- a/kombine/clustered_kde.py
+++ b/kombine/clustered_kde.py
@@ -244,7 +244,7 @@ class KDE(object):
         # store transformation variables for drawing random values
         alphas = abs(data).max(axis=0)
         ms = 1./alphas
-        m_i, m_j = numpy.meshgrid(ms, ms)
+        m_i, m_j = np.meshgrid(ms, ms)
         ms = m_i * m_j
         self._draw_cov = ms * self._kernel_cov
         self._scale_fac = alphas


### PR DESCRIPTION
There appears to be numerical precision error in `numpy.random.multivariate_normal` which can cause the draws produced by `KDE` to not be distributed correctly. The problem arises when you have one parameter that is orders of magnitude smaller than the other parameters. Here is an example where the problem arises: [link](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/from_scratch/scatter_movie-0-60000-100.mp4).

In that run, `amp220` (next-to-last parameter in the corner plots; if it's difficult to see, you can find the full-resolution frames [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/from_scratch/frames_scatter-0-60000-100/)) is O(1e-20), whereas all of the other parameters are O(1)-O(100). This run was done with an update interval set to every 500 samples. The problem appears after [iteration 6500](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/from_scratch/frames_scatter-0-60000-100/all_params-06600.png) and (more dramatically) after [sample 49000](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/from_scratch/frames_scatter-0-60000-100/all_params-49100.png), when all of the walkers quickly jump to the maximum `amp220` allowed by the prior, even though these are at much lower log posterior values.

I saved the kde used at sample 48500 and sample 49000. [Here is a 1D hist](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/start-49000/draw_hist-48500.png) comparing the distribution of samples of `amp220` values that were used to build the kde (black line) to the distribution of values produced by the kde's draw function (blue line) at iteration 48500, when the corner plots look good. The two match well. [Here is the same plot at iteration 49000](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/start-49000/draw_hist-49000.png), when the corner plots go crazy. As you can see, the drawn distribution is completely off.

I traced this bug to the call to `multivariate_normal`. [Here is a simple script](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/start-49000/orig_covar.py) that reproduces the problem. Run it on [this data](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/start-49000/kde_data-48500.npy), which are the sample points used in the kde at sample 48500, and you get the correct results. Run it again on [this data](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/start-49000/kde_data-49000.npy), which are the sample points used in the kde at sample 49000, and you'll see the error. There's no dramatic differences between those sample files, nor is there any dramatic difference in the calculated covariance matrices. This is why I think there's some numerical precision issue in `multivariate_normal` (maybe it casts values to single-precision internally?) that the latter realization is tickling.

In any event, this patch fixes the problem by storing a scaled covariance matrix to use in `multivariate_normal`. This matrix scales the covariance matrix such that the maximum value of all parameters is 1. After values are drawn, the parameters are re-scaled to their correct range. [Here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/start-49000/scaled_draw_hist-49000.png) is the distribution plot using the data at iteration 49000 with this fix. And [here](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/from_scratch_with_fix/scatter_movie-0-60000-100.mp4) is the above PE run with this patch. There is now no jump to low posterior values at after [iteration 6500](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/from_scratch_with_fix/frames_scatter-0-60000-100/all_params-06600.png) or [49000](https://www.atlas.aei.uni-hannover.de/~cdcapano/LSC/projects/area_theorem/gw150914/joint_runs/try3-err_check/from_scratch_with_fix/frames_scatter-0-60000-100/all_params-49100.png).