### PR TITLE
Updated setup.py and CI configuration for python 2.7, 3.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,12 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - deps='numpy scipy nose coverage'
-  - conda create -q -n test-environment --yes $deps "python=$TRAVIS_PYTHON_VERSION"
+  - conda create -q -n test-environment --yes "python=$TRAVIS_PYTHON_VERSION"
   - source activate test-environment
   - python setup.py install
+
+before_script:
+  - pip install nose coverage
 
 script:
   - nosetests --nologcapture -a '!slow' --with-coverage --cover-package kombine

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,20 @@
 language: python
+
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 
 before_install:
-    - pip install codecov
+  - pip install --upgrade pip
 
 install:
-  - sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-  - conda create -q -n test-environment --yes "python=$TRAVIS_PYTHON_VERSION"
-  - source activate test-environment
-  - python setup.py install
+  - python -m pip install .
 
 before_script:
-  - pip install nose coverage
+  - python -m pip install nose coverage codecov
 
 script:
   - nosetests --nologcapture -a '!slow' --with-coverage --cover-package kombine

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,17 @@ setup(
     include_package_data=True,
     packages=['kombine'],
     install_requires=['numpy', 'scipy'],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'License :: OSI Approved :: MIT License',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ setup(
     url='https://github.com/bfarr/kombine',
     include_package_data=True,
     packages=['kombine'],
+    install_requires=['numpy', 'scipy'],
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     include_package_data=True,
     packages=['kombine'],
     install_requires=['numpy', 'scipy'],
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',


### PR DESCRIPTION
This PR updates the `setup.py` file to include `install_requires` and `classifiers`, each of which improve the metadata of the package.

I also modified the CI to not manually install `numpy` and `scipy`, but rather rely on the dependency specification in `setup.py` to do it automatically.