### PR TITLE
Better pbar

### DIFF
--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -242,6 +242,12 @@ class Sampler(object):
         :param verbose: (optional)
             Print status messages each time a milestone is reached in the burnin.
 
+        :param callback: (optional)
+            Callback to use (default to None)
+
+        :param progress: (optional)
+            Boolean flag to report progress of burnin() / MCMC steps through a progress bar. Needs tqdm installed
+
         :param kwargs: (optional)
             The rest is passed to :meth:`run_mcmc`.
 
@@ -338,7 +344,6 @@ class Sampler(object):
 
             if callback is not None:
                 callback(self)
-
 
             # Quit if we hit the max
             if self.iterations >= max_iter:
@@ -490,7 +495,6 @@ class Sampler(object):
 
             self._lnpost = np.concatenate((self._lnpost, np.zeros((iterations, self.nwalkers))))
             self._lnprop = np.concatenate((self._lnprop, np.zeros((iterations, self.nwalkers))))
-
 
         for i in range(iterations):
             try:
@@ -876,6 +880,9 @@ class Sampler(object):
 
         :param blob0: (optional)
             The list of blob data for walkers at positions `p0`.
+
+        :param progress: (optional)
+            Boolean flag to turn on progress bar reporting through MCMC iterations
 
         :param kwargs: (optional)
             The rest is passed to :meth:`sample`.

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -184,10 +184,10 @@ class Sampler(object):
             import tqdm
             self.tqdm = tqdm
             if in_notebook():
-                pbar = self.tqdm.tqdm_notebook(desc="Burning in until Constant Acceptence Rate", position=0, leave=True,
+                pbar = self.tqdm.tqdm_notebook(desc="Burning in until Constant Acceptence Rate over {} ACLs".format(t), position=0, leave=True,
                                                total=t)
             else:
-                pbar = self.tqdm.tqdm(desc="Burning in until Constant Acceptence Rate", position=0, leave=True,
+                pbar = self.tqdm.tqdm(desc="Burning in until Constant Acceptence Rate over {} ACLs".format(t), position=0, leave=True,
                                       total=t)
         return pbar, dynamic_pbar_update
 

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -14,8 +14,7 @@ from .clustered_kde import optimized_kde, TransdimensionalKDE
 
 def dynamic_pbar_update(iter, test_size, acc, pbar=None):
     if pbar is not None:
-        pbar.set_postfix_str('| single_step_acceptence = {0} | test_stepsize = {1} >= 16'.format(acc,test_size),
-                             refresh=False)
+        pbar.set_postfix_str('| Single-Step Acceptence:{0} | Test Stepsize:{1} >= 16'.format(acc, test_size))
         pbar.update(iter - pbar.n)
 
 
@@ -922,10 +921,13 @@ class Sampler(object):
                         blob0 = None
 
         pbar = self._get_finite_pbar(progress, N)
+        iter = 0
         for results in self.sample(p0, lnpost0, lnprop0, blob0, N, **kwargs):
+            iter += 1
             if pbar is not None:
                 pbar.update(1)
-                pbar.set_postfix_str("| Last step Acc Rate: {}".format(self.acceptance_fraction[-1]))
+                pbar.set_postfix_str("{}/{} Walkers Accepted| Last step Acc Rate: {}".format(np.count_nonzero(self.acceptance[iter]),
+                                                                                             self.nwalkers, self.acceptance_fraction[-1]))
 
         # Store the results for later continuation and toss out the blob
         self._last_run_mcmc_result = results[:3]

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -12,9 +12,10 @@ from scipy.stats import chisquare
 from .clustered_kde import optimized_kde, TransdimensionalKDE
 
 
-def print_fn(iter, test_size, acc, pbar):
-    pbar.set_postfix_str('| single_step_acceptence = {0} | test_stepsize = {1} >= 16'.format(acc,test_size), refresh=False)
-    pbar.update(iter - pbar.n)
+def print_fn(iter, test_size, acc, pbar=None):
+    if pbar is not None:
+        pbar.set_postfix_str('| single_step_acceptence = {0} | test_stepsize = {1} >= 16'.format(acc,test_size), refresh=False)
+        pbar.update(iter - pbar.n)
 
 
 def in_notebook():

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -14,7 +14,7 @@ from .clustered_kde import optimized_kde, TransdimensionalKDE
 
 def dynamic_pbar_update(iter, test_size, acc, pbar=None):
     if pbar is not None:
-        pbar.set_postfix_str('| Single-Step Acceptence:{0} | Test Stepsize:{1} >= 16'.format(acc, test_size))
+        pbar.set_postfix_str('| Single-Step Acceptence Rate: {0} | Test Stepsize: {1} >= 16'.format(acc, test_size))
         pbar.update(iter - pbar.n)
 
 
@@ -184,9 +184,9 @@ class Sampler(object):
             import tqdm
             self.tqdm = tqdm
             if in_notebook():
-                pbar = self.tqdm.tqdm_notebook(desc="Burning in until constant Acc Rate", position=0, leave=True)
+                pbar = self.tqdm.tqdm_notebook(desc="Burning in until Constant Acceptence Rate", position=0, leave=True)
             else:
-                pbar = self.tqdm.tqdm(desc="Burning in until constant Acc Rate", position=0, leave=True)
+                pbar = self.tqdm.tqdm(desc="Burning in until Constant Acceptence Rate", position=0, leave=True)
         return pbar, dynamic_pbar_update
 
     def _get_finite_pbar(self, progress, N):
@@ -196,9 +196,9 @@ class Sampler(object):
                 import tqdm
                 self.tqdm = tqdm
             if in_notebook():
-                pbar = self.tqdm.tqdm_notebook(total=N, desc="running MCMC")
+                pbar = self.tqdm.tqdm_notebook(total=N, desc="Running MCMC")
             else:
-                pbar = self.tqdm.tqdm(total=N, desc="running MCMC")
+                pbar = self.tqdm.tqdm(total=N, desc="Running MCMC")
         return pbar
 
     def burnin(self, p0=None, lnpost0=None, lnprop0=None, blob0=None,
@@ -926,7 +926,7 @@ class Sampler(object):
             iter += 1
             if pbar is not None:
                 pbar.update(1)
-                pbar.set_postfix_str("{}/{} Walkers Accepted| Last step Acc Rate: {}".format(np.count_nonzero(self.acceptance[iter]),
+                pbar.set_postfix_str("| {}/{} Walkers Accepted | Last step Acc Rate: {}".format(np.count_nonzero(self.acceptance[iter]),
                                                                                              self.nwalkers, self.acceptance_fraction[-1]))
 
         # Store the results for later continuation and toss out the blob

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -318,7 +318,6 @@ class Sampler(object):
             # Make sure we're taking at least one step
             test_interval = max(test_interval, 1)
             sampling_ct += 1
-            pbar_status(step_size, last_step_size, last_acc_rate, pbar)
 
             if verbose:
                 if ~np.isinf(max_iter):
@@ -339,6 +338,8 @@ class Sampler(object):
 
             if callback is not None:
                 callback(self)
+
+            pbar_status(step_size, last_step_size, last_acc_rate, pbar)
 
             # Quit if we hit the max
             if self.iterations >= max_iter:
@@ -925,13 +926,13 @@ class Sampler(object):
                         blob0 = None
 
         pbar = self._get_finite_pbar(progress, N)
-        iter = self.iterations
+        it = self.iterations
         for results in self.sample(p0, lnpost0, lnprop0, blob0, N, **kwargs):
             if pbar is not None:
                 pbar.update(1)
-                pbar.set_postfix_str("| {}/{} Walkers Accepted | Last step Acc Rate: {}".format(np.count_nonzero(self.acceptance[iter]),
-                                                                                             self.nwalkers, self.acceptance_fraction[-1]))
-                iter += 1
+                pbar.set_postfix_str("| {}/{} Walkers Accepted | Last step Acc Rate: {}".format(np.count_nonzero(self.acceptance[it]),
+                                                                                             self.nwalkers, self.acceptance_fraction[it]))
+                it += 1
 
         # Store the results for later continuation and toss out the blob
         self._last_run_mcmc_result = results[:3]

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -13,7 +13,7 @@ from .clustered_kde import optimized_kde, TransdimensionalKDE
 
 
 def print_fn(iter, test_size, acc, pbar):
-    pbar.set_postfix_str(f'| single_step_acceptence = {acc} | test_stepsize = {test_size} >= 16', refresh=False)
+    pbar.set_postfix_str('| single_step_acceptence = {0} | test_stepsize = {1} >= 16'.format(acc,test_size), refresh=False)
     pbar.update(iter - pbar.n)
 
 
@@ -923,7 +923,7 @@ class Sampler(object):
         for results in self.sample(p0, lnpost0, lnprop0, blob0, N, **kwargs):
             if pbar is not None:
                 pbar.update(1)
-                pbar.set_postfix_str(f"| Last step Acc Rate: {self.acceptance_fraction[-1]}")
+                pbar.set_postfix_str("| Last step Acc Rate: {}".format(self.acceptance_fraction[-1]))
 
         # Store the results for later continuation and toss out the blob
         self._last_run_mcmc_result = results[:3]

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -14,7 +14,7 @@ from .clustered_kde import optimized_kde, TransdimensionalKDE
 
 def dynamic_pbar_update(step_size, last_step_size, acc, pbar=None):
     if pbar is not None:
-        pbar.set_postfix_str('| Single-Step Acceptence Rate: {0}'.format(acc))
+        pbar.set_postfix_str('| Single-Step Acceptence Rate: {0:.3f}'.format(acc))
         pbar.update(step_size-last_step_size)
 
 
@@ -930,7 +930,7 @@ class Sampler(object):
         for results in self.sample(p0, lnpost0, lnprop0, blob0, N, **kwargs):
             if pbar is not None:
                 pbar.update(1)
-                pbar.set_postfix_str("| {}/{} Walkers Accepted | Last step Acc Rate: {}".format(np.count_nonzero(self.acceptance[it]),
+                pbar.set_postfix_str("| {0}/{1} Walkers Accepted | Last step Acc Rate: {2:.3f}".format(np.count_nonzero(self.acceptance[it]),
                                                                                              self.nwalkers, self.acceptance_fraction[it]))
                 it += 1
 

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -921,13 +921,13 @@ class Sampler(object):
                         blob0 = None
 
         pbar = self._get_finite_pbar(progress, N)
-        iter = 0
+        iter = self.iterations
         for results in self.sample(p0, lnpost0, lnprop0, blob0, N, **kwargs):
-            iter += 1
             if pbar is not None:
                 pbar.update(1)
                 pbar.set_postfix_str("| {}/{} Walkers Accepted | Last step Acc Rate: {}".format(np.count_nonzero(self.acceptance[iter]),
                                                                                              self.nwalkers, self.acceptance_fraction[-1]))
+                iter += 1
 
         # Store the results for later continuation and toss out the blob
         self._last_run_mcmc_result = results[:3]

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -12,9 +12,10 @@ from scipy.stats import chisquare
 from .clustered_kde import optimized_kde, TransdimensionalKDE
 
 
-def print_fn(iter, test_size, acc, pbar=None):
+def dynamic_pbar_update(iter, test_size, acc, pbar=None):
     if pbar is not None:
-        pbar.set_postfix_str('| single_step_acceptence = {0} | test_stepsize = {1} >= 16'.format(acc,test_size), refresh=False)
+        pbar.set_postfix_str('| single_step_acceptence = {0} | test_stepsize = {1} >= 16'.format(acc,test_size),
+                             refresh=False)
         pbar.update(iter - pbar.n)
 
 
@@ -187,7 +188,7 @@ class Sampler(object):
                 pbar = self.tqdm.tqdm_notebook(desc="Burning in until constant Acc Rate", position=0, leave=True)
             else:
                 pbar = self.tqdm.tqdm(desc="Burning in until constant Acc Rate", position=0, leave=True)
-        return pbar, print_fn
+        return pbar, dynamic_pbar_update
 
     def _get_finite_pbar(self, progress, N):
         pbar = None
@@ -267,7 +268,7 @@ class Sampler(object):
         if self._transd:
             freeze_transd = True
             self._burnin_spaces = ~p0.mask
-        pbar, print_func = self._get_dynamci_pbar(progress)
+        pbar, pbar_status = self._get_dynamci_pbar(progress)
         max_iter = np.inf
         if max_steps is not None:
             max_iter = start + max_steps
@@ -315,7 +316,7 @@ class Sampler(object):
             # Make sure we're taking at least one step
             test_interval = max(test_interval, 1)
             sampling_ct += 1
-            print_func(sampling_ct, step_size, last_acc_rate, pbar)
+            pbar_status(sampling_ct, step_size, last_acc_rate, pbar)
 
             if verbose:
                 if ~np.isinf(max_iter):

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -184,10 +184,10 @@ class Sampler(object):
             import tqdm
             self.tqdm = tqdm
             if in_notebook():
-                pbar = self.tqdm.tqdm_notebook(desc="Burning in until Constant Acceptence Rate over {} ACLs".format(t), position=0, leave=True,
+                pbar = self.tqdm.tqdm_notebook(desc="Burning in until Const Acc Rate over {} ACLs".format(t), position=0, leave=True,
                                                total=t)
             else:
-                pbar = self.tqdm.tqdm(desc="Burning in until Constant Acceptence Rate over {} ACLs".format(t), position=0, leave=True,
+                pbar = self.tqdm.tqdm(desc="Burning in until Const Acc Rate over {} ACLs".format(t), position=0, leave=True,
                                       total=t)
         return pbar, dynamic_pbar_update
 

--- a/kombine/sampler.py
+++ b/kombine/sampler.py
@@ -339,7 +339,6 @@ class Sampler(object):
             if callback is not None:
                 callback(self)
 
-            pbar_status(step_size, last_step_size, last_acc_rate, pbar)
 
             # Quit if we hit the max
             if self.iterations >= max_iter:
@@ -350,6 +349,7 @@ class Sampler(object):
             if self.consistent_acceptance_rate(window_size=step_size*act, critical_pval=critical_pval):
                 if verbose:
                     print('Acceptance rate constant over ', step_size, ' ACTs')
+                pbar_status(step_size, last_step_size, last_acc_rate, pbar)
                 last_step_size = step_size
                 step_size *= 2
             else:


### PR DESCRIPTION
First attempt at creating a better progress bar for `sampler.burnin()` method. 

Because of nested progress bars and printing interaction, I made it so we override verbose such that `verbose=False` in sampler.burnin() if using a progress bar. If the progress bar displays information clearly enough I think this is valid. 